### PR TITLE
Dev ops: Adding basic jenkins file to main also adding Junit to pom and a simple example Test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,13 @@
+pipeline {
+	agent any
+	stages {
+		stage('Build') {
+			steps {
+				withMaven {
+					sh "mvn clean install"
+				}
+				sh 'echo "Hello World"'
+			}
+		}
+	}
+}

--- a/src/test/java/com/revature/controllers/TestControllerIntegration.java
+++ b/src/test/java/com/revature/controllers/TestControllerIntegration.java
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.revature.models.Profile;
-import com.revature.reverb.ReverbApplication;
+import com.revature.ReverbApplication;
 
 @RunWith(SpringRunner.class)
 //@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT,
@@ -40,7 +40,6 @@ public class TestControllerIntegration {
 	     "header_img",
 	     "about_me" );
 	
-//		mvc.perform(get())
 		
 		
 	}

--- a/src/test/java/com/revature/controllers/TestControllerIntegration.java
+++ b/src/test/java/com/revature/controllers/TestControllerIntegration.java
@@ -1,21 +1,14 @@
 package com.revature.controllers;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.core.env.Environment;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import com.revature.models.Profile;
+import com.revature.repositories.ProfileRepository;
 import com.revature.ReverbApplication;
 
 @RunWith(SpringRunner.class)
@@ -23,26 +16,26 @@ import com.revature.ReverbApplication;
 //properties = {"server.port=8081",
 //		"management.server.port=8082"})
 @SpringBootTest(classes = ReverbApplication.class)
-@ActiveProfiles("reverb-backend-integration-test")
 public class TestControllerIntegration {
-	
+
 	@Autowired
-	private ProfileController profilecontroller;
-	
+	private ProfileController profilectrl;
+
+	@Autowired
+	private ProfileRepository profilereptest;
+
 	@Test
-	public void devops_profile_test() throws Exception{
-		
-		
-		Profile tester = new Profile( 1,
-	     "first_name",
-	     "last_name",
-	     "profile_img",
-	     "header_img",
-	     "about_me" );
-	
-		
-		
+	public void devops_profile_test() throws Exception {
+
+		Profile tester = new Profile(1, "first_name", "last_name", "profile_img", "header_img", "about_me");
+
+		profilereptest.save(tester);
+
+		Optional<Profile> retrievedProfile = profilectrl.findProfileById(tester.getId());
+
+		assertThat(tester.getFirst_name()).isEqualTo(retrievedProfile.get().getFirst_name());
+
+
 	}
-		
-		
+
 }

--- a/src/test/java/com/revature/controllers/TestControllerIntegration.java
+++ b/src/test/java/com/revature/controllers/TestControllerIntegration.java
@@ -1,0 +1,49 @@
+package com.revature.controllers;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.revature.models.Profile;
+import com.revature.reverb.ReverbApplication;
+
+@RunWith(SpringRunner.class)
+//@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT,
+//properties = {"server.port=8081",
+//		"management.server.port=8082"})
+@SpringBootTest(classes = ReverbApplication.class)
+@ActiveProfiles("reverb-backend-integration-test")
+public class TestControllerIntegration {
+	
+	@Autowired
+	private ProfileController profilecontroller;
+	
+	@Test
+	public void devops_profile_test() throws Exception{
+		
+		
+		Profile tester = new Profile( 1,
+	     "first_name",
+	     "last_name",
+	     "profile_img",
+	     "header_img",
+	     "about_me" );
+	
+//		mvc.perform(get())
+		
+		
+	}
+		
+		
+}

--- a/src/test/resources/application-integration-testing.properties
+++ b/src/test/resources/application-integration-testing.properties
@@ -1,0 +1,16 @@
+
+server.port=8081
+spring.application.name=reverb-backend-integration-test
+
+# Database Credentials
+spring.datasource.url=jdbc:h2:mem:memdb
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.h2.console.enabled=true
+
+# JPA Settings
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# Defer the Hibernate Initialization
+spring.jpa.defer-datasource-initialization=true


### PR DESCRIPTION
This Merge adds quite a bit for the little amount of code it is. With the addition of the jenkins file to main we can begin automated testing(currently only Build and 2 tests) for all pull requests moving forwards. The changes to the Pom add in Junit so people can use that for unit testing and also some integration tests. This way we can start moving toward our 70% coverage sooner, rather than later. Lastly, there are two files file associated with a new integration test. the test file still needs comments on my part added in so it is understandable, and the second file is a potential test config  file that may come into play in the future if we decided to have different profiles for unit vs integration testing.